### PR TITLE
Add AshSwap pools addresses for mainnet

### DIFF
--- a/accounts/erd1qqqqqqqqqqqqqpgq5l05l0ts4lphdktx33apl0ss9rzf4r244fvsva6j53.json
+++ b/accounts/erd1qqqqqqqqqqqqqpgq5l05l0ts4lphdktx33apl0ss9rzf4r244fvsva6j53.json
@@ -1,0 +1,6 @@
+{
+  "name": "AshSwap: BUSD/WEGLD V2 Pool",
+  "description": "",
+  "tags": ["ashswap", "v2-pool"],
+  "icon": "ashswap"
+}

--- a/accounts/erd1qqqqqqqqqqqqqpgqn7969pvzaatp8p9yu6u5h2ce2gyw0x9j4fvsplvthl.json
+++ b/accounts/erd1qqqqqqqqqqqqqpgqn7969pvzaatp8p9yu6u5h2ce2gyw0x9j4fvsplvthl.json
@@ -1,0 +1,6 @@
+{
+  "name": "AshSwap: USDT/ASH V2 Pool",
+  "description": "",
+  "tags": ["ashswap", "v2-pool"],
+  "icon": "ashswap"
+}

--- a/accounts/erd1qqqqqqqqqqqqqpgqs8p2v9wr8j48vqrmudcj94wu47kqra3r4fvshfyd9c.json
+++ b/accounts/erd1qqqqqqqqqqqqqpgqs8p2v9wr8j48vqrmudcj94wu47kqra3r4fvshfyd9c.json
@@ -1,0 +1,6 @@
+{
+  "name": "AshSwap: USDC/USDT/BUSD Stable Pool",
+  "description": "",
+  "tags": ["ashswap", "stable-swap", "stable-pool"],
+  "icon": "ashswap"
+}


### PR DESCRIPTION
We have deployed new pools:

- `USDC/USDT/BUSD`: [erd1qqqqqqqqqqqqqpgqs8p2v9wr8j48vqrmudcj94wu47kqra3r4fvshfyd9c](https://explorer.multiversx.com/accounts/erd1qqqqqqqqqqqqqpgqs8p2v9wr8j48vqrmudcj94wu47kqra3r4fvshfyd9c)
- `BUSD/WEGLD`: [erd1qqqqqqqqqqqqqpgq5l05l0ts4lphdktx33apl0ss9rzf4r244fvsva6j53](https://explorer.multiversx.com/accounts/erd1qqqqqqqqqqqqqpgq5l05l0ts4lphdktx33apl0ss9rzf4r244fvsva6j53)
- `USDT/ASH`: [erd1qqqqqqqqqqqqqpgqn7969pvzaatp8p9yu6u5h2ce2gyw0x9j4fvsplvthl](https://explorer.multiversx.com/accounts/erd1qqqqqqqqqqqqqpgqn7969pvzaatp8p9yu6u5h2ce2gyw0x9j4fvsplvthl)