### PR TITLE
ZPAY locked account

### DIFF
--- a/tokens/ZPAY-247875/info.json
+++ b/tokens/ZPAY-247875/info.json
@@ -10,6 +10,9 @@
     "coinmarketcap": "https://coinmarketcap.com/currencies/zoidpay/",
     "coingecko": "https://www.coingecko.com/en/coins/zoid-pay"
   },
+  "lockedAccounts": {
+    "erd136kalm60ndyyps7paexvz38pf09f58f7nzqg8tw60p9pq7ygyspsx6ux89": "Owner Account"
+  },
   "status": "active",
   "extraTokens": [
     "ZPAYWEGLD-34e5c1",


### PR DESCRIPTION
Locked tokens & unlocked tokens should be placed in different accounts.